### PR TITLE
The call to check if 'delay' is available is now called on the manage…

### DIFF
--- a/lib/devise_campaignable/model.rb
+++ b/lib/devise_campaignable/model.rb
@@ -60,7 +60,7 @@ module Devise
                 # If class responds to delayed job then return the delayed instance
                 # but if it doesn't look like delayed job implemented just return the
                 # underlying manager object directly.
-                respond_to?(:delay) ? manager.delay(:queue => 'devise_campaignable') : manager
+                manager.respond_to?(:delay) ? manager.delay(:queue => 'devise_campaignable') : manager
             end
 
             # Subscribe all users as a batch.


### PR DESCRIPTION
…r model instead of the devise model, which is more accurate. This fixes #2 which was being thrown for users not using DelayedJob.

In time I'd like to switch all the queuing over to ActuveJob or some other cross-queue mechanism.
