### PR TITLE
Trap common errors

### DIFF
--- a/lib/devise_campaignable/adapters/mailchimp.rb
+++ b/lib/devise_campaignable/adapters/mailchimp.rb
@@ -6,10 +6,6 @@ module Devise
 
             # Subscribe an email to the instantiated list.
             def subscribe(email, merge_vars={})
-              if /\@example\.com/ =~ email
-                Rails.logger.warn "Not subscribing example email: #{email}"
-                return
-              end
 	            # Logic for mailchimp subcription.
 	            api.lists(@campaignable_list_id).members(subscriber_hash(email)).upsert(body: {
 	                :email_address => email,

--- a/lib/devise_campaignable/model.rb
+++ b/lib/devise_campaignable/model.rb
@@ -45,6 +45,11 @@ module Devise
             # Ask the list manager to unsubscribe this devise models email.
             self.class.list_manager.unsubscribe(self.email)
         end
+        
+        # Returns true if it's a valid email for subscribing
+        def self.valid_campaign_email?(email)
+            email.present? && /\@example\.(com|net|org|edu)$/ !~ email
+        end
 
         private
 
@@ -64,7 +69,7 @@ module Devise
             end
             
             def campaignable_user?
-                self.email.present? && /\@example\.(com|net|org|edu)$/ !~ self.email
+                Campaignable.valid_campaign_email? self.email
             end
 
         module ClassMethods
@@ -87,7 +92,7 @@ module Devise
             # Subscribe all users as a batch.
             def subscribe_all
                 # Get an array of all the email addresses accociated with this devise class.
-                emails = all.map(&:email)
+                emails = all.map(&:email).select {|e| Devise::Models::Campaignable.valid_campaign_email? e}
 
                 # Ask the list managed to subscibe all of these emails.
                 list_manager.batch_subscribe(emails)
@@ -96,12 +101,12 @@ module Devise
             # Unsubscribe all users as a batch.
             def unsubscribe_all
                 # Get an array of all the email addresses accociated with this devise class.
-                emails = all.map(&:email)
+                emails = all.map(&:email).select {|e| Devise::Models::Campaignable.valid_campaign_email? e}
 
                 # Ask the list managed to subscibe all of these emails.
                 list_manager.batch_unsubscribe(emails)                
             end
-
+            
             # Set the configuration variables for the modeule.
             Devise::Models.config(self, :campaignable_api_key, :campaignable_list_id, :campaignable_vendor, :campaignable_additional_fields)
         end

--- a/lib/devise_campaignable/model.rb
+++ b/lib/devise_campaignable/model.rb
@@ -20,11 +20,11 @@ module Devise
         # Add the callbacks to the user model.
         included do
             # Callback to subscribe the user whenever the record is created
-            after_create :subscribe
+            after_create :subscribe, if: :campaignable_user?
             # Callback to see if the subscription for this users needs updating.
-            after_update :update_subscription
+            after_update :update_subscription, if: :campaignable_user?
             # Callback to unsubscribe the user when they are destroyed.
-            after_destroy :unsubscribe
+            after_destroy :unsubscribe, if: :campaignable_user?
         end
 
         # Method to subscibe the user to the configrued mailing list.
@@ -61,6 +61,10 @@ module Devise
 
                 # Compact to the hash to remove any empty data.
                 additional_fields.compact
+            end
+            
+            def campaignable_user?
+                self.email.present? && /\@example\.(com|net|org|edu)$/ !~ self.email
             end
 
         module ClassMethods


### PR DESCRIPTION
Thanks for this great module! I experienced a couple of errors using it in my app:
1. If the user doesn't have an email (e.g. it's a Twitter Oauth user), or the email is an @example.com email, the app crashes with a MailChimp error.
2. If you try to unsubscribe an email that has been deleted from MailChimp (or was never added), there's a MailChimp error.

This PR makes the following changes:
1. The callbacks (and subscribe/unsubscribe_all) are only called if the user has an email and it's not an @example.com/net/org/edu email - these emails are banned in MailChimp, and they also correspond to the `Faker::Internet.safe_email` users that might exist in people's RSpecs.
2. If a 404 error is received when unsubscribing in the MailChimp adapter, this module logs and carries on.

Let me know if this looks good to you! 
