### PR TITLE
Fix specs for Devise 4.x+

### DIFF
--- a/devise_campaignable.gemspec
+++ b/devise_campaignable.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-
-  spec.add_runtime_dependency "devise", "~> 3.2.0"
+  spec.add_development_dependency "activemodel"
+  
+  spec.add_runtime_dependency "devise", ">= 3.2.0"
   spec.add_runtime_dependency "gibbon", "~> 2.0"
 end


### PR DESCRIPTION
Add activemodel as a dev dependency. The specs load Devise, which in turn loads active_support/dependencies but this isn't itself an explicit dependency for devise.
