### PR TITLE
Fix bug when an unsubscribe fails

### DIFF
--- a/lib/devise_campaignable/adapters/mailchimp.rb
+++ b/lib/devise_campaignable/adapters/mailchimp.rb
@@ -31,7 +31,7 @@ module Devise
 	            api.lists(@campaignable_list_id).members(subscriber_hash(email)).update(body: { status: "unsubscribed" })
             rescue Gibbon::MailChimpError => e
               raise unless e.status_code == 404
-              Rails.logger.warn "unsubscribe: User #{self.email} not found!"
+              Rails.logger.warn "unsubscribe: User #{email} not found!"
             end
 
             # Subscribe all users as a batch.


### PR DESCRIPTION
When an unsubscribe call fails, the rescue block logs the failed email address. The email address should be the local variable `email` rather than the method `self.email`, which is undefined.