### PR TITLE
Travis build failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
-  - 2.1.5
-  - 2.2.0
-  - rbx-2
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
+  - ruby-head
 script: bundle exec rspec .

--- a/devise_campaignable.gemspec
+++ b/devise_campaignable.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "rack", "~> 1.6.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "activemodel"


### PR DESCRIPTION
Changed the RVM verions we use for the Travis build to match those used on the Devise project so that we can maintain compatibility with them.

Also locked Rack down to 1.x as 2.x requires later versions of ruby.