### PR TITLE
The MailChimp adapter now upcases the merge_field keys as for some re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ The unique ID of the list to which you want your users to be subscribed. Again, 
 
 #### config.campaignable_additional_fields (optional)
 
-An array of symbols which denote attributes on the model you want sent to the campaign vendor. Can be things like Name, Age, Address. Defaults to no additional fields.
+An array of symbols which denote attributes on the model you want sent to the campaign vendor. Can be things like Name, Age, Address. Defaults to no additional fields. 
+
+**MailChimp Users: You need to have added merge fields with matching names to your MailChimp list before this will work, the merge fields should match the attribute on your user model, capitalized. i.e. an attribute such as 'name' should have a merge field on the list of 'NAME'.**
 
 ## Model Configuration
 

--- a/lib/devise_campaignable/model.rb
+++ b/lib/devise_campaignable/model.rb
@@ -48,6 +48,7 @@ module Devise
         
         # Returns true if it's a valid email for subscribing
         def self.valid_campaign_email?(email)
+            # Check that the email is present, and that it's not an example domain.
             email.present? && /\@example\.(com|net|org|edu)$/ !~ email
         end
 
@@ -69,6 +70,7 @@ module Devise
             end
             
             def campaignable_user?
+                # Check the email is valid, so callbacks not fired for example domains.
                 Campaignable.valid_campaign_email? self.email
             end
 


### PR DESCRIPTION
…ason the lower case keys don't appear to work anymore since the upgrade from APi v2 to v3. I added some additional comments and a little statement in the README which covers this and how to configured the merge fields on the mailing list.