### PR TITLE
Rescue MailChimpError exceptions in the subscribe method

### DIFF
--- a/lib/devise_campaignable/adapters/mailchimp.rb
+++ b/lib/devise_campaignable/adapters/mailchimp.rb
@@ -11,7 +11,10 @@ module Devise
 	                :email_address => email,
                     :status => "subscribed",
                     :merge_fields => prep_merge_fields(merge_vars) # Include additional variables to be stored.
-	            })
+                })
+            rescue Gibbon::MailChimpError => e
+                # Log mailchimp api errors into the rails logger.
+                Rails.logger.warn "subscribe: MailChimp error: #{e}"
             end
 
             # Update an existing subscription.

--- a/lib/devise_campaignable/adapters/mailchimp.rb
+++ b/lib/devise_campaignable/adapters/mailchimp.rb
@@ -11,7 +11,7 @@ module Devise
 	                :email_address => email,
                     :status => "subscribed",
                     :merge_fields => prep_merge_fields(merge_vars) # Include additional variables to be stored.
-                })
+	            })
             rescue Gibbon::MailChimpError => e
                 # Log mailchimp api errors into the rails logger.
                 Rails.logger.warn "subscribe: MailChimp error: #{e}"


### PR DESCRIPTION
This change addresses issue #17 by catching MailChimp connection errors and simply logging them.

The reason for this change is to ensure that devise_campaignable doesn't prevent devise from creating a user if for example, we can't connect to the MailChimp API. In this case, we now skip subscribing them and log the warning.

Not sure if there are other concerns related to this, but this works as-is in my testing. Thanks to @SirRawlins for the help!