### PR TITLE
A few bugfixes for edge-cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The unique ID of the list to which you want your users to be subscribed. Again, 
 
 An array of symbols which denote attributes on the model you want sent to the campaign vendor. Can be things like Name, Age, Address. Defaults to no additional fields. 
 
-**MailChimp Users: You need to have added merge fields with matching names to your MailChimp list before this will work, the merge fields should match the attribute on your user model, capitalized. i.e. an attribute such as 'name' should have a merge field on the list of 'NAME'.**
+**MailChimp Users: You need to have added merge fields with matching names to your MailChimp list before this will work, the merge fields should match the attribute on your user model, capitalized. i.e. an attribute such as 'name' should have a merge field on the list of 'NAME'. If your attribute is more than 10 characters (MailChimp's limit) then use the first 10 characters.**
 
 ## Model Configuration
 

--- a/lib/devise_campaignable/adapters/mailchimp.rb
+++ b/lib/devise_campaignable/adapters/mailchimp.rb
@@ -87,7 +87,7 @@ module Devise
                 # Prepare the merge fields to be sent to MailChimp.
                 def prep_merge_fields(merge_fields)
                     # Upper-case all the keys as this is how MC expect them.
-                    merge_fields.map { |k, v| [k.upcase, v] }.to_h
+                    merge_fields.map { |k, v| [k.to_s.upcase.first(10), v] }.to_h
                 end
 
                 # Convert the members email into a hash

--- a/lib/devise_campaignable/adapters/mailchimp.rb
+++ b/lib/devise_campaignable/adapters/mailchimp.rb
@@ -22,7 +22,6 @@ module Devise
                 # Update the existing member details.
                 api.lists(@campaignable_list_id).members(subscriber_hash(old_email)).update(body: {
                     :email_address => new_email,
-                    :status => "subscribed",
                     :merge_fields => prep_merge_fields(merge_vars) # Include additional variables to be stored.
                 })
             end

--- a/lib/devise_campaignable/model.rb
+++ b/lib/devise_campaignable/model.rb
@@ -37,7 +37,7 @@ module Devise
         def update_subscription
             # Only change the subscription if the models email
             # address has been changed.
-            self.class.list_manager.update_subscription(self.email_was, self.email, campaignable_additional_fields) if email_changed? || campaignable_additional_fields.any? {|f| attribute_changed? f}
+            self.class.list_manager.update_subscription(self.email_was, self.email, campaignable_additional_fields) if saved_change_to_email? || campaignable_additional_fields.keys.any? {|f| saved_change_to_attribute? f}
         end
 
         # Method to unsubscribe the user from the configured mailing list.

--- a/lib/devise_campaignable/model.rb
+++ b/lib/devise_campaignable/model.rb
@@ -37,7 +37,7 @@ module Devise
         def update_subscription
             # Only change the subscription if the models email
             # address has been changed.
-            self.class.list_manager.update_subscription(self.email_was, self.email, campaignable_additional_fields) if self.email_changed?
+            self.class.list_manager.update_subscription(self.email_was, self.email, campaignable_additional_fields) if email_changed? || campaignable_additional_fields.any? {|f| attribute_changed? f}
         end
 
         # Method to unsubscribe the user from the configured mailing list.


### PR DESCRIPTION
Hey @SirRawlins - I last submitted a PR for this project over 4 years ago but now I find I want to use it again and have a few changes for edge-cases in this PR that you might be interested in:

1. Mailchimp merge vars have a maximum length of 10 chars, so this changes the mapping between attribute and merge var to be "all uppercase + first 10 chars" instead of just the uppercase.
2. It uses `saved_change_to_email?` instead of `email_changed?` because in recent Rails `email_changed?` always returns false in an `after_update` callback (it's not changed after the save completes).
3. Also checks the merge vars for changes.
4. Doesn't set subscriptions back to 'subscribed' every time another param changes. I figure this was just a mistake?

Let me know if you want any tests or anything.